### PR TITLE
Update cwd_card_slider.js

### DIFF
--- a/js/cwd_card_slider.js
+++ b/js/cwd_card_slider.js
@@ -91,8 +91,8 @@ jQuery(document).ready(function($) {
 		// build buttons
 		var nextprev_html = '';
 		if (card_count > 1) {
-			$(viewer_band).before('<div class="pips" aria-hidden="true"></div>').wrap('<div class="mask"></div>');
-			nextprev_html = '<div class="next-prev" aria-hidden="true"><button class="prev"><span class="sr-only">Previous Slide Set</span><span class="fa fa-angle-left"></span></button><button class="next"><span class="sr-only">Next Slide Set</span><span class="fa fa-angle-right"></span></button></div>';
+			$(viewer_band).before('<div class="pips"></div>').wrap('<div class="mask"></div>');
+			nextprev_html = '<div class="next-prev"><button class="prev"><span class="sr-only">Previous Slide Set</span><span class="fa fa-angle-left"></span></button><button class="next"><span class="sr-only">Next Slide Set</span><span class="fa fa-angle-right"></span></button></div>';
 			$(this).append(nextprev_html);
 			$(this).find('.next, .prev').click(function(e) {
 				if ($(this).hasClass('prev')) {


### PR DESCRIPTION
As per Sean Gnau:

_This may have been incorrectly suggested otherwise in the past - but it is not okay to use aria-hidden on focusable elements.  We cannot hide button controls from screen readers.  Some screen reader users have vision, and use it to help read content, it is not okay to hide controls away from them._